### PR TITLE
Update node-event

### DIFF
--- a/api/config.land.ts
+++ b/api/config.land.ts
@@ -18,6 +18,11 @@ const config = {
   dynamodb: {
     region: "us-east-1",
   },
+  nodeEvent: {
+    host: "greycollar.land",
+    port: 8000,
+    protocol: "https",
+  },
 };
 
 export default config;

--- a/api/config.land.ts
+++ b/api/config.land.ts
@@ -18,7 +18,7 @@ const config = {
   dynamodb: {
     region: "us-east-1",
   },
-  nodeEvent: {
+  event: {
     host: "greycollar.land",
     port: 8000,
     protocol: "https",

--- a/api/config.ts
+++ b/api/config.ts
@@ -18,6 +18,11 @@ const config = {
   dynamodb: {
     region: "us-east-1",
   },
+  nodeEvent: {
+    host: "localhost",
+    port: 8080,
+    protocol: "http",
+  },
 };
 
 export default config;

--- a/api/config.ts
+++ b/api/config.ts
@@ -18,7 +18,7 @@ const config = {
   dynamodb: {
     region: "us-east-1",
   },
-  nodeEvent: {
+  event: {
     host: "localhost",
     port: 8080,
     protocol: "http",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.35.0",
-        "@modelcontextprotocol/sdk": "^1.15.1",
         "@canmingir/link": "^1.1.1",
         "@canmingir/link-express": "^1.6.0",
+        "@modelcontextprotocol/sdk": "^1.15.1",
         "googleapis": "^148.0.0",
         "jsonwebtoken": "^9.0.2",
-        "nuc-node-event-test": "^1.0.13",
+        "nuc-node-event-test": "^1.0.15",
         "openai": "^4.79.4",
         "puppeteer": "^24.1.0",
         "socket.io": "^4.8.1"
@@ -12334,9 +12334,9 @@
       "license": "MIT"
     },
     "node_modules/nuc-node-event-test": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/nuc-node-event-test/-/nuc-node-event-test-1.0.13.tgz",
-      "integrity": "sha512-q0hh7CtlJfqDiEqedQF5I61HYqUM1Q49XaHZokF5bJ3AkpMvuYpbGRPChlqnXqD4ZnuZws0bX/5+OfrYeR+RhA==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/nuc-node-event-test/-/nuc-node-event-test-1.0.15.tgz",
+      "integrity": "sha512-6PmpuNbTN++8exShHShP0+oXxRzHoc6oRX7N4pOVjfv0f2rrw/ZgSJW0jrLk/C1fVNM7Olp9XM0dCYnVI41RmA==",
       "dependencies": {
         "chalk": "^4.1.2",
         "socket.io": "^4.8.1",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,9 +12,9 @@
         "@canmingir/link": "^1.1.1",
         "@canmingir/link-express": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.15.1",
+        "@nucleoidai/node-event": "^1.1.1",
         "googleapis": "^148.0.0",
         "jsonwebtoken": "^9.0.2",
-        "nuc-node-event-test": "^1.0.15",
         "openai": "^4.79.4",
         "puppeteer": "^24.1.0",
         "socket.io": "^4.8.1"
@@ -3513,6 +3513,32 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@nucleoidai/node-event": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@nucleoidai/node-event/-/node-event-1.1.1.tgz",
+      "integrity": "sha512-Mi+c3jEBxO3oveA3lmHUyCo03DhIA+HEVTiqeH6xIWmUVziMVA6EmLIf26/4HyNNE+AUjy2m966t989wgOfFEg==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "socket.io": "^4.8.1",
+        "socket.io-client": "^4.8.1",
+        "uuid": "^9.0.0"
+      },
+      "bin": {
+        "server": "server/server.js"
+      }
+    },
+    "node_modules/@nucleoidai/node-event/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@nucleoidai/react-event": {
@@ -12332,32 +12358,6 @@
       "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
       "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
       "license": "MIT"
-    },
-    "node_modules/nuc-node-event-test": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/nuc-node-event-test/-/nuc-node-event-test-1.0.15.tgz",
-      "integrity": "sha512-6PmpuNbTN++8exShHShP0+oXxRzHoc6oRX7N4pOVjfv0f2rrw/ZgSJW0jrLk/C1fVNM7Olp9XM0dCYnVI41RmA==",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "socket.io": "^4.8.1",
-        "socket.io-client": "^4.8.1",
-        "uuid": "^9.0.0"
-      },
-      "bin": {
-        "server": "server/server.js"
-      }
-    },
-    "node_modules/nuc-node-event-test/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/numeral": {
       "version": "2.0.6",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,7 +12,7 @@
         "@canmingir/link": "^1.1.1",
         "@canmingir/link-express": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.15.1",
-        "@nucleoidai/node-event": "^1.1.1",
+        "@nucleoidai/node-event": "^1.1.2",
         "googleapis": "^148.0.0",
         "jsonwebtoken": "^9.0.2",
         "openai": "^4.79.4",
@@ -3516,9 +3516,9 @@
       }
     },
     "node_modules/@nucleoidai/node-event": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@nucleoidai/node-event/-/node-event-1.1.1.tgz",
-      "integrity": "sha512-Mi+c3jEBxO3oveA3lmHUyCo03DhIA+HEVTiqeH6xIWmUVziMVA6EmLIf26/4HyNNE+AUjy2m966t989wgOfFEg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@nucleoidai/node-event/-/node-event-1.1.2.tgz",
+      "integrity": "sha512-qVfZsrUDFT2hRaebsmpHzg5jNVTRW8C4Nd0qJeKb+c5i9TZ2D2Yjy5GDFXaOlQoftGOT8g20SEc0a56PeaXtBA==",
       "dependencies": {
         "chalk": "^4.1.2",
         "socket.io": "^4.8.1",

--- a/api/package.json
+++ b/api/package.json
@@ -12,12 +12,12 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.35.0",
-    "@modelcontextprotocol/sdk": "^1.15.1",
     "@canmingir/link": "^1.1.1",
     "@canmingir/link-express": "^1.6.0",
+    "@modelcontextprotocol/sdk": "^1.15.1",
     "googleapis": "^148.0.0",
     "jsonwebtoken": "^9.0.2",
-    "nuc-node-event-test": "^1.0.13",
+    "nuc-node-event-test": "^1.0.15",
     "openai": "^4.79.4",
     "puppeteer": "^24.1.0",
     "socket.io": "^4.8.1"

--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,7 @@
     "@canmingir/link": "^1.1.1",
     "@canmingir/link-express": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.15.1",
-    "@nucleoidai/node-event": "^1.1.1",
+    "@nucleoidai/node-event": "^1.1.2",
     "googleapis": "^148.0.0",
     "jsonwebtoken": "^9.0.2",
     "openai": "^4.79.4",

--- a/api/package.json
+++ b/api/package.json
@@ -15,9 +15,9 @@
     "@canmingir/link": "^1.1.1",
     "@canmingir/link-express": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.15.1",
+    "@nucleoidai/node-event": "^1.1.1",
     "googleapis": "^148.0.0",
     "jsonwebtoken": "^9.0.2",
-    "nuc-node-event-test": "^1.0.15",
     "openai": "^4.79.4",
     "puppeteer": "^24.1.0",
     "socket.io": "^4.8.1"

--- a/api/server.ts
+++ b/api/server.ts
@@ -5,7 +5,7 @@ import config from "./config";
 import dotenv from "dotenv";
 import http from "http";
 import models from "./src/models";
-import { nodeEvent } from "nuc-node-event-test/client";
+import { nodeEvent } from "@nucleoidai/node-event/client";
 
 dotenv.config();
 

--- a/api/server.ts
+++ b/api/server.ts
@@ -24,10 +24,12 @@ platform.init(config).then(() => {
 
   models.init();
 
+  const { host, port, protocol } = config.nodeEvent;
+
   nodeEvent.init({
-    host: "localhost",
-    port: Number(8080),
-    protocol: "http",
+    host,
+    port,
+    protocol,
   });
 
   server.listen(process.env.PORT || 4000, () => {

--- a/api/server.ts
+++ b/api/server.ts
@@ -28,7 +28,7 @@ platform.init(config).then(() => {
 
   event.init({
     host,
-    port,
+    port: Number(port),
     protocol,
   });
 

--- a/api/server.ts
+++ b/api/server.ts
@@ -3,9 +3,9 @@ import * as platform from "@canmingir/link-express";
 import { Server } from "socket.io";
 import config from "./config";
 import dotenv from "dotenv";
+import { event } from "@nucleoidai/node-event/client";
 import http from "http";
 import models from "./src/models";
-import { nodeEvent } from "@nucleoidai/node-event/client";
 
 dotenv.config();
 
@@ -26,7 +26,7 @@ platform.init(config).then(() => {
 
   const { host, port, protocol } = config.event;
 
-  nodeEvent.init({
+  event.init({
     host,
     port,
     protocol,

--- a/api/server.ts
+++ b/api/server.ts
@@ -24,7 +24,7 @@ platform.init(config).then(() => {
 
   models.init();
 
-  const { host, port, protocol } = config.nodeEvent;
+  const { host, port, protocol } = config.event;
 
   nodeEvent.init({
     host,

--- a/api/src/functions/session.ts
+++ b/api/src/functions/session.ts
@@ -1,6 +1,6 @@
 import Conversation from "../models/Conversation";
 import Session from "../models/Session";
-import { nodeEvent } from "@nucleoidai/node-event/client";
+import { event } from "@nucleoidai/node-event/client";
 import { publish } from "../lib/Event";
 import { v4 as uuid } from "uuid";
 
@@ -59,7 +59,7 @@ async function addConversation({
       content,
     });
   } else {
-    nodeEvent.publish("AI_MESSAGED", {
+    event.publish("AI_MESSAGED", {
       colleagueId,
       sessionId,
       conversationId: conversation.id,

--- a/api/src/functions/session.ts
+++ b/api/src/functions/session.ts
@@ -1,6 +1,6 @@
 import Conversation from "../models/Conversation";
 import Session from "../models/Session";
-import { nodeEvent } from "nuc-node-event-test/client";
+import { nodeEvent } from "@nucleoidai/node-event/client";
 import { publish } from "../lib/Event";
 import { v4 as uuid } from "uuid";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.15.1",
         "@canmingir/link": "^1.1.1",
         "@canmingir/link-express": "^1.6.0",
+        "@modelcontextprotocol/sdk": "^1.15.1",
         "concurrently": "^9.1.2",
         "cors": "^2.8.5",
         "express": "^4.18.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "concurrently": "^9.1.2",
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "http-proxy-middleware": "^3.0.1",
-        "nuc-node-event-test": "^1.0.13"
+        "http-proxy-middleware": "^3.0.1"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -3058,11 +3057,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@socket.io/component-emitter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
-    },
     "node_modules/@svgdotjs/svg.draggable.js": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@svgdotjs/svg.draggable.js/-/svg.draggable.js-3.0.5.tgz",
@@ -3122,14 +3116,6 @@
       },
       "peerDependencies": {
         "@svgdotjs/svg.js": "^3.2.4"
-      }
-    },
-    "node_modules/@types/cors": {
-      "version": "2.8.19",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
-      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/debug": {
@@ -3478,14 +3464,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
-    },
-    "node_modules/base64id": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-      "engines": {
-        "node": "^4.5.0 || >= 5.9"
-      }
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -4228,95 +4206,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/engine.io": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
-      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
-      "dependencies": {
-        "@types/cors": "^2.8.12",
-        "@types/node": ">=10.0.0",
-        "accepts": "~1.3.4",
-        "base64id": "2.0.0",
-        "cookie": "~0.7.2",
-        "cors": "~2.8.5",
-        "debug": "~4.3.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1"
-      },
-      "engines": {
-        "node": ">=10.2.0"
-      }
-    },
-    "node_modules/engine.io-client": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
-      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1",
-        "xmlhttprequest-ssl": "~2.1.1"
-      }
-    },
-    "node_modules/engine.io-client/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/engine.io-client/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/engine.io-parser": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/engine.io/node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/engine.io/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/engine.io/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/enquire.js": {
       "version": "2.1.6",
@@ -6994,20 +6883,6 @@
       "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
       "license": "MIT"
     },
-    "node_modules/nuc-node-event-test": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/nuc-node-event-test/-/nuc-node-event-test-1.0.13.tgz",
-      "integrity": "sha512-q0hh7CtlJfqDiEqedQF5I61HYqUM1Q49XaHZokF5bJ3AkpMvuYpbGRPChlqnXqD4ZnuZws0bX/5+OfrYeR+RhA==",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "socket.io": "^4.8.1",
-        "socket.io-client": "^4.8.1",
-        "uuid": "^9.0.0"
-      },
-      "bin": {
-        "server": "server/server.js"
-      }
-    },
     "node_modules/numeral": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
@@ -8492,142 +8367,6 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/socket.io": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
-      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
-      "dependencies": {
-        "accepts": "~1.3.4",
-        "base64id": "~2.0.0",
-        "cors": "~2.8.5",
-        "debug": "~4.3.2",
-        "engine.io": "~6.6.0",
-        "socket.io-adapter": "~2.5.2",
-        "socket.io-parser": "~4.2.4"
-      },
-      "engines": {
-        "node": ">=10.2.0"
-      }
-    },
-    "node_modules/socket.io-adapter": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
-      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
-      "dependencies": {
-        "debug": "~4.3.4",
-        "ws": "~8.17.1"
-      }
-    },
-    "node_modules/socket.io-adapter/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socket.io-adapter/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/socket.io-client": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
-      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.2",
-        "engine.io-client": "~6.6.1",
-        "socket.io-parser": "~4.2.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/socket.io-client/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socket.io-client/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/socket.io-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/socket.io-parser/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socket.io-parser/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/socket.io/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socket.io/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
     "node_modules/sort-asc": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
@@ -9404,34 +9143,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/xmlhttprequest-ssl": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
-      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -25,13 +25,12 @@
     "typecheck": "npm run typecheck:dashboard"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.15.1",
     "@canmingir/link": "^1.1.1",
     "@canmingir/link-express": "^1.6.0",
+    "@modelcontextprotocol/sdk": "^1.15.1",
     "concurrently": "^9.1.2",
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "http-proxy-middleware": "^3.0.1",
-    "nuc-node-event-test": "^1.0.13"
+    "http-proxy-middleware": "^3.0.1"
   }
 }


### PR DESCRIPTION
Introduces a new nodeEvent configuration section in both config.ts and config.land.ts, allowing environment-specific host, port, and protocol settings. Updates server.ts to use these config values for nodeEvent initialization. Also bumps nuc-node-event-test dependency to version 1.0.15.