### PR TITLE
Update @canmingir/link to v1.1.3 and refactor imports

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dashboard.greycollar.ai",
       "version": "0.0.0",
       "dependencies": {
-        "@canmingir/link": "^1.1.1",
+        "@canmingir/link": "^1.1.3",
         "@chatscope/chat-ui-kit-react": "^2.0.3",
         "@cypress/vite-dev-server": "^5.1.1",
         "@emoji-mart/react": "^1.1.1",
@@ -1941,9 +1941,9 @@
       "license": "MIT"
     },
     "node_modules/@canmingir/link": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@canmingir/link/-/link-1.1.1.tgz",
-      "integrity": "sha512-2NHlyXZvy94hZIMe0H4rzrBokSmDy+BWotuW2JTrkc3p09566og/H8xa0sE2Xci9dUz6gDReiGe3FC4RWCOTAA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@canmingir/link/-/link-1.1.3.tgz",
+      "integrity": "sha512-sCOiPslfi7XJWiAHi75evpQL8dIyRbsmpMK9Pr2/wz4VKTWDJgIkmTkan20ad4RzFljSPUibrkJQTYCZxXP/kA==",
       "dependencies": {
         "@chatscope/chat-ui-kit-react": "^1.10.1",
         "@emoji-mart/data": "^1.1.2",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -17,7 +17,7 @@
     "build:storybook": "storybook build"
   },
   "dependencies": {
-    "@canmingir/link": "^1.1.1",
+    "@canmingir/link": "^1.1.3",
     "@chatscope/chat-ui-kit-react": "^2.0.3",
     "@cypress/vite-dev-server": "^5.1.1",
     "@emoji-mart/react": "^1.1.1",

--- a/dashboard/src/components/ChatInput/chat.config.ts
+++ b/dashboard/src/components/ChatInput/chat.config.ts
@@ -1,4 +1,4 @@
-import http from "../../http";
+import http from "@canmingir/link/platform/http";
 import { publish } from "@nucleoidai/react-event";
 
 const learnAction = async (command) => {

--- a/dashboard/src/components/ResponsibilityChat/ResponsibilityChat.tsx
+++ b/dashboard/src/components/ResponsibilityChat/ResponsibilityChat.tsx
@@ -2,7 +2,7 @@ import Box from "@mui/material/Box";
 import InlineChatInput from "../../widgets/ChatInput/InlineChatInput";
 import React from "react";
 import ResponsibilityChatContent from "./ResponsibilityChatContent";
-import http from "../../http";
+import http from "@canmingir/link/platform/http";
 import { publish } from "@nucleoidai/react-event";
 import { useParams } from "react-router-dom";
 import useResponsibility from "../../hooks/useResponsibility";

--- a/dashboard/src/hooks/useAIEngines.ts
+++ b/dashboard/src/hooks/useAIEngines.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApi";
 
 import { useCallback, useEffect, useState } from "react";

--- a/dashboard/src/hooks/useAcquiredIntegrations.ts
+++ b/dashboard/src/hooks/useAcquiredIntegrations.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApiV2";
 import { useCallback } from "react";
 

--- a/dashboard/src/hooks/useChat.ts
+++ b/dashboard/src/hooks/useChat.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApi";
 import { useLocation } from "react-router-dom";
 import useMessage from "./useMessage";

--- a/dashboard/src/hooks/useColleague.ts
+++ b/dashboard/src/hooks/useColleague.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import { publish } from "@nucleoidai/react-event";
 import useApi from "./useApi";
 

--- a/dashboard/src/hooks/useColleagueV2.ts
+++ b/dashboard/src/hooks/useColleagueV2.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApiV2";
 
 import { publish, useEvent } from "@nucleoidai/react-event";

--- a/dashboard/src/hooks/useColleagues.ts
+++ b/dashboard/src/hooks/useColleagues.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import { storage } from "@nucleoidjs/webstorage";
 import useApi from "./useApi";
 

--- a/dashboard/src/hooks/useCommunications.ts
+++ b/dashboard/src/hooks/useCommunications.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApiV2";
 
 import { publish, useEvent } from "@nucleoidai/react-event";

--- a/dashboard/src/hooks/useIntegrations.ts
+++ b/dashboard/src/hooks/useIntegrations.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApi";
 
 import { useCallback, useEffect, useState } from "react";

--- a/dashboard/src/hooks/useIntegrationsV2.ts
+++ b/dashboard/src/hooks/useIntegrationsV2.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import { publish } from "@nucleoidai/react-event";
 import useApi from "./useApiV2";
 import { useCallback } from "react";

--- a/dashboard/src/hooks/useKnowledge.ts
+++ b/dashboard/src/hooks/useKnowledge.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApiV2";
 
 import { publish, useEvent } from "@nucleoidai/react-event";

--- a/dashboard/src/hooks/useMessage.ts
+++ b/dashboard/src/hooks/useMessage.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import { publish } from "@nucleoidai/react-event";
 import useApi from "./useApi";
 import { useCallback } from "react";

--- a/dashboard/src/hooks/useOrganization.ts
+++ b/dashboard/src/hooks/useOrganization.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApi";
 
 import { publish, useEvent } from "@nucleoidai/react-event";

--- a/dashboard/src/hooks/useOrganizations.ts
+++ b/dashboard/src/hooks/useOrganizations.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApi";
 import { useEvent } from "@nucleoidai/react-event";
 

--- a/dashboard/src/hooks/useOrganziationsV2.ts
+++ b/dashboard/src/hooks/useOrganziationsV2.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApiV2";
 
 import { publish, useEvent } from "@nucleoidai/react-event";

--- a/dashboard/src/hooks/useResponsibility.ts
+++ b/dashboard/src/hooks/useResponsibility.ts
@@ -1,5 +1,5 @@
 import { convertToNodesAndEdges } from "../components/ResponsibilityFlow/flowAdapter";
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import { publish } from "@nucleoidai/react-event";
 import useApi from "./useApiV2";
 import { v4 as uuidv4 } from "uuid";

--- a/dashboard/src/hooks/useSession.ts
+++ b/dashboard/src/hooks/useSession.ts
@@ -1,5 +1,5 @@
 import config from "../../config";
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import { io } from "socket.io-client";
 import { publish } from "@nucleoidai/react-event";
 import { storage } from "@nucleoidjs/webstorage";

--- a/dashboard/src/hooks/useSettingsState.ts
+++ b/dashboard/src/hooks/useSettingsState.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 
 import {
   actionTypes as settingsActionTypes,

--- a/dashboard/src/hooks/useStatistics.ts
+++ b/dashboard/src/hooks/useStatistics.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApi";
 import { useEvent } from "@nucleoidai/react-event";
 

--- a/dashboard/src/hooks/useSupervise.ts
+++ b/dashboard/src/hooks/useSupervise.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApi";
 import { useEvent } from "@nucleoidai/react-event";
 

--- a/dashboard/src/hooks/useSupervisings.ts
+++ b/dashboard/src/hooks/useSupervisings.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApi";
 import { useSocket } from "./useSocket";
 

--- a/dashboard/src/hooks/useSupervisingsV2.ts
+++ b/dashboard/src/hooks/useSupervisingsV2.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApiV2";
 import { useCallback } from "react";
 

--- a/dashboard/src/hooks/useTask.ts
+++ b/dashboard/src/hooks/useTask.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApi";
 
 import { useCallback, useEffect, useState } from "react";

--- a/dashboard/src/hooks/useTasks.ts
+++ b/dashboard/src/hooks/useTasks.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApi";
 
 import { publish, useEvent } from "@nucleoidai/react-event";

--- a/dashboard/src/hooks/useTeam.ts
+++ b/dashboard/src/hooks/useTeam.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import { publish } from "@nucleoidai/react-event";
 import useApi from "./useApi";
 

--- a/dashboard/src/hooks/useTeamDetails.ts
+++ b/dashboard/src/hooks/useTeamDetails.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApi";
 
 import { useCallback, useEffect, useState } from "react";

--- a/dashboard/src/hooks/useTeams.ts
+++ b/dashboard/src/hooks/useTeams.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import { publish } from "@nucleoidai/react-event";
 import useApi from "./useApi";
 

--- a/dashboard/src/hooks/useTeamsV2.ts
+++ b/dashboard/src/hooks/useTeamsV2.ts
@@ -1,4 +1,4 @@
-import http from "../http";
+import http from "@canmingir/link/platform/http";
 import useApi from "./useApiV2";
 
 import { publish, useEvent } from "@nucleoidai/react-event";

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@canmingir/link": "^1.1.1",
+        "@canmingir/link": "^1.1.3",
         "@canmingir/link-express": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.15.1",
         "concurrently": "^9.1.2",
@@ -892,9 +892,9 @@
       }
     },
     "node_modules/@canmingir/link": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@canmingir/link/-/link-1.1.1.tgz",
-      "integrity": "sha512-2NHlyXZvy94hZIMe0H4rzrBokSmDy+BWotuW2JTrkc3p09566og/H8xa0sE2Xci9dUz6gDReiGe3FC4RWCOTAA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@canmingir/link/-/link-1.1.3.tgz",
+      "integrity": "sha512-sCOiPslfi7XJWiAHi75evpQL8dIyRbsmpMK9Pr2/wz4VKTWDJgIkmTkan20ad4RzFljSPUibrkJQTYCZxXP/kA==",
       "dependencies": {
         "@chatscope/chat-ui-kit-react": "^1.10.1",
         "@emoji-mart/data": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typecheck": "npm run typecheck:dashboard"
   },
   "dependencies": {
-    "@canmingir/link": "^1.1.1",
+    "@canmingir/link": "^1.1.3",
     "@canmingir/link-express": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.15.1",
     "concurrently": "^9.1.2",


### PR DESCRIPTION
Upgraded @canmingir/link from v1.1.1 to v1.1.3 in both dashboard and root dependencies. Refactored all imports of http in dashboard components and hooks to use '@canmingir/link/platform/http' for consistency and improved maintainability.