### PR TITLE
Grafana Config

### DIFF
--- a/monitoring/grafana/Dockerfile
+++ b/monitoring/grafana/Dockerfile
@@ -5,6 +5,9 @@ COPY provisioning /etc/grafana/provisioning/
 ENV GF_SECURITY_ADMIN_PASSWORD=admin
 ENV GF_USERS_ALLOW_SIGN_UP=false
 ENV GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-simple-json-datasource
+ENV GF_AUTH_ANONYMOUS_ENABLED=true
+ENV GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+ENV GF_AUTH_DISABLE_LOGIN_FORM=true
 
 EXPOSE 3000
 

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -4,6 +4,6 @@ datasources:
   - name: Prometheus
     type: prometheus
     access: proxy
-    url: http://host.docker.internal:9090
+    url: https://prometheus.gentleflower-99ef02e0.eastus.azurecontainerapps.io:443
     isDefault: true
     editable: true


### PR DESCRIPTION
Anonymous access is now enabled in Grafana with admin role, and the login form is disabled. The Prometheus datasource URL has been updated to use an external HTTPS endpoint.